### PR TITLE
Fixed render flex on email verification page

### DIFF
--- a/lib/Screens/email_verification_screen.dart
+++ b/lib/Screens/email_verification_screen.dart
@@ -24,10 +24,11 @@ class _EmailVerificationScreenState extends State<EmailVerificationScreen> {
     return Scaffold(
       body: Column(
         children: [
-          Image.asset(
-            'assets/images/verify1.png',
-            height: 550,
-            width: 300,
+          Expanded(
+            child: Image.asset(
+              'assets/images/verify1.png',
+              fit: BoxFit.contain,
+            ),
           ),
           const Text(
             'Verify your email before continuing !!',
@@ -75,6 +76,7 @@ class _EmailVerificationScreenState extends State<EmailVerificationScreen> {
               ),
             ),
           ),
+          SizedBox(height: 10),
         ],
       ),
     );


### PR DESCRIPTION
### Related Issue
- Fixes #54 

### Proposed Changes
- Removed height and width of the image
- Wrapped image widget in expand and  sized box of height 10 in bottom

### Additional Information
- Any additional information about the change

### Checklist
- [ ✓] Tested
- [✓ ] No Conflicts
- [✓ ] Change In Code
- [ ✕] Change In Documentation

### Screenshots 
![image](https://user-images.githubusercontent.com/34944818/111096472-99980500-8565-11eb-8f26-ef51248ba71d.png)


