### PR TITLE
Enabled crashlytics (android)

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -11,7 +11,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-ecosystem/action-add-labels@v1
         with:
-          github_token: ${{ github.token }}
           labels: |
             under_review
             review_requested

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 apply plugin: 'com.google.gms.google-services'
+apply plugin: 'com.google.firebase.crashlytics'
 
 android {
     compileSdkVersion 29

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,6 +9,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.5.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.3.5'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.2.0'
     }
 }
 

--- a/lib/Screens/Login_Screen.dart
+++ b/lib/Screens/Login_Screen.dart
@@ -1,13 +1,15 @@
 // ignore_for_file: non_constant_identifier_names
 
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:book_donation/Utils/Styles.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_switch/flutter_switch.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-// import 'package:book_donation/Screens/home_screen.dart';
+// import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:book_donation/Services/google_sign_in.dart';
 import 'package:book_donation/Services/facebook_sign_in.dart';
-import 'package:book_donation/Screens/email_verification_screen.dart';
+// import 'package:book_donation/Screens/email_verification_screen.dart';
+// import 'package:book_donation/Screens/home_screen.dart';
 
 import '../router/route_constants.dart';
 
@@ -107,6 +109,15 @@ class _LoginPageState extends State<LoginPage> {
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceAround,
                       children: [
+                        // TODO:
+                        /// Crash the app once to set up crashlytics in firebase
+                        /// to be done on iOS (uncomment below iconbutton wiget and crashlytics import at the top)
+
+                        // IconButton(
+                        //     icon: const Icon(Icons.dangerous),
+                        //     onPressed: () {
+                        //       FirebaseCrashlytics.instance.crash();
+                        //     }),
                         const Text(
                           "Login",
                           style: TextStyle(
@@ -255,7 +266,8 @@ class _LoginPageState extends State<LoginPage> {
                       // notify(context, "Log-in Problem",
                       //     "Please Verify Email at First and then log in...Email Verification Link Send to Your Reistered Mail");
                     }
-                  }).catchError((e) {
+                  }).catchError((e, StackTrace s) {
+                    FirebaseCrashlytics.instance.recordError(e.toString(), s);
                     if (e.toString() ==
                         "[firebase_auth/user-not-found] There is no user record corresponding to this identifier. The user may have been deleted.") {
                       notify(context, "Log-in Problem",
@@ -481,7 +493,8 @@ class _LoginPageState extends State<LoginPage> {
                     await signedUpUser.user.sendEmailVerification();
                     notify(context, "Congrats! Sign up Complete",
                         "Please Log-In to Continue");
-                  }).catchError((e) {
+                  }).catchError((e, StackTrace s) {
+                    FirebaseCrashlytics.instance.recordError(e.toString(), s);
                     if (e.toString() ==
                         "[firebase_auth/email-already-in-use] The email address is already in use by another account.") {
                       notify(context, "Sorry! Account Conflict",

--- a/lib/Services/facebook_sign_in.dart
+++ b/lib/Services/facebook_sign_in.dart
@@ -1,4 +1,5 @@
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 // import 'package:flutter/material.dart';
 import 'package:flutter_facebook_login/flutter_facebook_login.dart';
 
@@ -17,7 +18,8 @@ Future<bool> handleFacebookSignin() async {
       try {
         await signinWithFacebook(result);
         return true;
-      } catch (e) {
+      } catch (e, s) {
+        FirebaseCrashlytics.instance.recordError(e.toString(), s);
         print(e);
         return false;
       }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:hive/hive.dart';
 import 'package:path_provider/path_provider.dart' as path_provider;
 import 'package:book_donation/Utils/Styles.dart';
@@ -23,8 +24,10 @@ Future<void> main() async {
 
   await Hive.openBox('preferences');
 
+  await Firebase.initializeApp(); // Initialize the Firebase App
+  FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterError;
+
   runApp(MyApp());
-  Firebase.initializeApp(); // Initialize the Firebase App
 }
 
 class MyApp extends StatefulWidget {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -239,6 +239,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
+  firebase_crashlytics:
+    dependency: "direct main"
+    description:
+      name: firebase_crashlytics
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
+  firebase_crashlytics_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_crashlytics_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   fixnum:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
     sdk: flutter
   firebase_auth: ^1.0.1
   firebase_core: ^1.0.1
+  firebase_crashlytics: ^1.0.0
   flutter_facebook_login: null
   flutter_switch: ^0.1.6-beta.1
   google_sign_in: null


### PR DESCRIPTION
### Related Issue
- Fixes #55  .

### Proposed Changes
- Enabled crashlytics for android.
- Sending error reports in every try-catch block

### Additional Information
- Turns out, we do need Xcode (Runner) to enable crashlytics in iOS. This is to be done.

### Checklist
- [ ] Tested
- [x] No Conflicts
- [x] Change In Code
- [ ] Change In Documentation