### PR TITLE
Resolved issue-129. Removed minFontSize

### DIFF
--- a/lib/Screens/intro_screen.dart
+++ b/lib/Screens/intro_screen.dart
@@ -109,7 +109,6 @@ class IntroductionState extends State<Introduction> {
                   child: const AutoSizeText(
                     'CONTINUE',
                     maxFontSize: 36,
-                    minFontSize: 21,
                     maxLines: 1,
                     style: TextStyle(
                         fontFamily: 'HanaleiFill',


### PR DESCRIPTION
### Related Issue
- The text on the button in the intro_screen, "CONTINUE" displayed only as "CONTIN" in my Redmi Phone.

### Proposed Changes
- Removed minFontSize from the AutoSizeText.

### Additional Information
- Text on the button works fine now.

### Checklist
- [x] Tested
- [x] No Conflicts
- [x] Change In Code
- [ ] Change In Documentation

### Screenshots (Optional)
