### PR TITLE
Fixed the WRONG ERROR MESSAGE when the email ID already existed(#140)

### DIFF
--- a/lib/Screens/Login_Screen.dart
+++ b/lib/Screens/Login_Screen.dart
@@ -637,8 +637,8 @@ class _LoginPageState extends State<LoginPage> {
                   if (e
                       .toString()
                       .contains('[firebase_auth/email-already-in-use]')) {
-                    notify(context, 'Email in Use',
-                        'Use another Email to Sign Up');
+                    notify(context, 'Email already exists',
+                        'Please Log-in using that');
                   }
 
                   if (e.toString().contains('[firebase_auth/weak-password]')) {


### PR DESCRIPTION
### Related Issue
-Fixed the error message when the email ID of an user already existed .

### Proposed Changes
- Change in the notifying dialog box with a different text message

